### PR TITLE
fix: 修复血精石满充能后重置问题

### DIFF
--- a/scripts/components/aipc_oldone.lua
+++ b/scripts/components/aipc_oldone.lua
@@ -27,10 +27,15 @@ local function OnIsDay(inst, isday)
 		local stones = TheSim:FindEntities(pt.x, pt.y, pt.z, 0.1, { "aip_bloodstone" })
 		local first = stones[1]
 		if first ~= nil and first.components.finiteuses ~= nil then
-			first.components.finiteuses:Use(-factor)
+			local finiteuses = first.components.finiteuses
+			local maxUses = finiteuses.total
 
-			if first.components.finiteuses:GetPercent() > 1 then
-				first.components.finiteuses:SetPercent(1)
+			-- 满充能时重复叠加会导致次数异常，直接按上限截断
+			if maxUses ~= nil and maxUses > 0 then
+				local currUses = finiteuses:GetUses()
+				if currUses < maxUses then
+					finiteuses:SetUses(math.min(maxUses, currUses + factor))
+				end
 			end
 		end
 	end


### PR DESCRIPTION
血精石充能逻辑修复，旧神因子在白天结算时对血精石的充能改为读取当前次数并按上限截断后写回，避免已满状态继续叠加导致次数异常从而出现“满充能后重置”的问题；同时保留原有的溢出处理路径，确保将多余因子稳定转化到背包中的血精石，不会再因满值边界触发造成充能表现反复。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab2564dac8330b4752c38347374de)