### PR TITLE
feat: 支持料理继承食材品质

### DIFF
--- a/scripts/configurations/skin/aip_endless_lotus.lua
+++ b/scripts/configurations/skin/aip_endless_lotus.lua
@@ -11,7 +11,7 @@ return skinUtil.CreateConfig({
 			id = "style_1",
 			name = {
 				english = "Endless Lotus",
-				chinese = "无尽之莲",
+				chinese = "无限之莲",
 			},
 		},
 		{
@@ -19,7 +19,7 @@ return skinUtil.CreateConfig({
 			prefab = PREFAB.."_2",
 			name = {
 				english = "Endless Lotus II",
-				chinese = "无尽之莲·二式",
+				chinese = "无限之莲·二式",
 			},
 		},
 		{
@@ -27,7 +27,7 @@ return skinUtil.CreateConfig({
 			prefab = PREFAB.."_3",
 			name = {
 				english = "Endless Lotus III",
-				chinese = "无尽之莲·三式",
+				chinese = "无限之莲·三式",
 			},
 		},
 	},

--- a/scripts/hooks/aip_edible_hook.lua
+++ b/scripts/hooks/aip_edible_hook.lua
@@ -3,6 +3,7 @@ local _G = GLOBAL
 -- 每高一级品质，正面效果增加 25%，负面效果减少 25%。
 local QUALITY_EFFECT_STEP = 0.25
 local DEFAULT_QUALITY = 1
+local POST_INIT_QUALITY_FOODS = {}
 
 -- 读取物品品质，没有品质的食材视作普通品质。
 local function getQuality(inst)
@@ -35,11 +36,40 @@ local function setupQuality(inst)
 end
 
 -- 有品质的料理只和同品质合堆，避免食用时品质被混掉。
-local function patchQualityStackable(inst)
-	if inst._aip_quality_stackable_patched then
+local function patchQualityStackableComponent(inst)
+	local stackable = inst.components.stackable
+
+	if stackable == nil or stackable._aip_quality_stackable_patched then
 		return
 	end
-	inst._aip_quality_stackable_patched = true
+	stackable._aip_quality_stackable_patched = true
+
+	local oldMergeType = stackable.aipMergeType
+	stackable.aipMergeType = function(this, other, source_pos)
+		if oldMergeType ~= nil then
+			if type(oldMergeType) == "function" then
+				if not oldMergeType(this, other, source_pos) then
+					return false
+				end
+			elseif type(oldMergeType) == "string" then
+				local otherMergeType = other.components.stackable ~= nil and other.components.stackable.aipMergeType or nil
+				if otherMergeType ~= oldMergeType then
+					return false
+				end
+			end
+		end
+
+		return getQuality(this) == getQuality(other)
+	end
+end
+
+-- 有品质的料理只和同品质合堆，避免食用时品质被混掉。
+local function patchQualityStackable(inst)
+	if inst._aip_quality_stackable_fn_patched then
+		patchQualityStackableComponent(inst)
+		return
+	end
+	inst._aip_quality_stackable_fn_patched = true
 
 	local oldCanStackWithFn = inst.stackable_CanStackWithFn
 	inst.stackable_CanStackWithFn = function(this, other)
@@ -50,35 +80,41 @@ local function patchQualityStackable(inst)
 		return getQuality(this) == getQuality(other)
 	end
 
-	if inst.components.stackable ~= nil then
-		local oldMergeType = inst.components.stackable.aipMergeType
-
-		inst.components.stackable.aipMergeType = function(this, other, source_pos)
-			if oldMergeType ~= nil then
-				if type(oldMergeType) == "function" then
-					if not oldMergeType(this, other, source_pos) then
-						return false
-					end
-				elseif type(oldMergeType) == "string" then
-					local otherMergeType = other.components.stackable ~= nil and other.components.stackable.aipMergeType or nil
-					if otherMergeType ~= oldMergeType then
-						return false
-					end
-				end
-			end
-
-			return getQuality(this) == getQuality(other)
-		end
-	end
+	patchQualityStackableComponent(inst)
 end
 
 -- 料理锅成品需要能承载食材平均品质。
-AddPrefabPostInitAny(function(inst)
+local function setupPreparedFoodQuality(inst)
 	if inst:HasTag("preparedfood") then
 		setupQuality(inst)
 		patchQualityStackable(inst)
 	end
-end)
+end
+
+-- 精确注册原版料理 prefab，避免每个 prefab 生成时都跑全局 Any hook。
+local function addPreparedFoodPostInit(name)
+	if name ~= nil and not POST_INIT_QUALITY_FOODS[name] then
+		POST_INIT_QUALITY_FOODS[name] = true
+		AddPrefabPostInit(name, setupPreparedFoodQuality)
+	end
+end
+
+local function addPreparedFoodPostInits(moduleName)
+	local ok, foods = pcall(_G.require, moduleName)
+	if not ok or foods == nil then
+		return
+	end
+
+	for name, data in pairs(foods) do
+		addPreparedFoodPostInit(data.name or name)
+	end
+end
+
+addPreparedFoodPostInits("preparedfoods")
+addPreparedFoodPostInits("preparedfoods_warly")
+addPreparedFoodPostInits("spicedfoods")
+
+_G.aipRegisterQualityPreparedFood = addPreparedFoodPostInit
 
 -- 有品质才加成；正数变强，负数变弱，普通品质不变。
 local function applyQualityBonus(value, edible)
@@ -105,6 +141,9 @@ AddComponentPostInit("edible", function(self)
 	local oldGetHunger = self.GetHunger
 	local oldGetSanity = self.GetSanity
 
+	-- 服务端添加 edible 时再次兜底，兼容其它已带 preparedfood 标签的料理。
+	setupPreparedFoodQuality(self.inst)
+
 	function self:GetHealth(eater, ...)
 		-- 生命先处理铁胃，再处理品质倍率。
 		local health = oldGetHealth(self, eater, ...)
@@ -125,6 +164,12 @@ AddComponentPostInit("edible", function(self)
 
 	function self:GetSanity(eater, ...)
 		return applyQualityBonus(oldGetSanity(self, eater, ...), self)
+	end
+end)
+
+AddComponentPostInit("stackable", function(self)
+	if self.inst:HasTag("preparedfood") and self.inst.components.aipc_quality ~= nil then
+		patchQualityStackable(self.inst)
 	end
 end)
 
@@ -158,11 +203,13 @@ AddComponentPostInit("stewer", function(self)
 			quality = getAverageQuality(self.inst.components.container.slots)
 		end
 
-		oldStartCooking(self, doer, ...)
+		local result = oldStartCooking(self, doer, ...)
 
 		if quality ~= nil and self.product ~= nil and self.targettime ~= nil then
 			self.aip_product_quality = quality
 		end
+
+		return result
 	end
 
 	function self:OnSave(...)

--- a/scripts/hooks/aip_edible_hook.lua
+++ b/scripts/hooks/aip_edible_hook.lua
@@ -23,6 +23,15 @@ local function getAverageQuality(slots)
 	return count > 0 and math.floor(total / count + 0.5) or nil
 end
 
+-- 调味站继承原料理品质，不让普通香料拉低成品品质。
+local function getPreparedFoodQuality(slots)
+	for _, item in pairs(slots) do
+		if item ~= nil and item:HasTag("preparedfood") then
+			return getQuality(item)
+		end
+	end
+end
+
 -- 给料理成品补上品质展示与品质组件。
 local function setupQuality(inst)
 	if inst.components.aipc_info_client == nil then
@@ -155,7 +164,8 @@ AddComponentPostInit("stewer", function(self)
 	function self:StartCooking(doer, ...)
 		local quality = nil
 		if self.targettime == nil and self.inst.components.container ~= nil then
-			quality = getAverageQuality(self.inst.components.container.slots)
+			local slots = self.inst.components.container.slots
+			quality = self.inst:HasTag("spicer") and getPreparedFoodQuality(slots) or getAverageQuality(slots)
 		end
 
 		local result = oldStartCooking(self, doer, ...)

--- a/scripts/hooks/aip_edible_hook.lua
+++ b/scripts/hooks/aip_edible_hook.lua
@@ -1,5 +1,84 @@
+local _G = GLOBAL
+
 -- 每高一级品质，正面效果增加 25%，负面效果减少 25%。
 local QUALITY_EFFECT_STEP = 0.25
+local DEFAULT_QUALITY = 1
+
+-- 读取物品品质，没有品质的食材视作普通品质。
+local function getQuality(inst)
+	return inst ~= nil and inst.components ~= nil and
+		inst.components.aipc_quality ~= nil and inst.components.aipc_quality:GetVal() or DEFAULT_QUALITY
+end
+
+-- 锅制食物使用整数品质，按所有食材的平均品质四舍五入。
+local function getAverageQuality(slots)
+	local total = 0
+	local count = 0
+
+	for _, item in pairs(slots) do
+		total = total + getQuality(item)
+		count = count + 1
+	end
+
+	return count > 0 and math.floor(total / count + 0.5) or nil
+end
+
+-- 给料理成品补上品质展示与品质组件。
+local function setupQuality(inst)
+	if inst.components.aipc_info_client == nil then
+		inst:AddComponent("aipc_info_client")
+	end
+
+	if inst.components.aipc_quality == nil then
+		inst:AddComponent("aipc_quality")
+	end
+end
+
+-- 有品质的料理只和同品质合堆，避免食用时品质被混掉。
+local function patchQualityStackable(inst)
+	if inst._aip_quality_stackable_patched then
+		return
+	end
+	inst._aip_quality_stackable_patched = true
+
+	local oldCanStackWithFn = inst.stackable_CanStackWithFn
+	inst.stackable_CanStackWithFn = function(this, other)
+		if oldCanStackWithFn ~= nil and not oldCanStackWithFn(this, other) then
+			return false
+		end
+
+		return getQuality(this) == getQuality(other)
+	end
+
+	if inst.components.stackable ~= nil then
+		local oldMergeType = inst.components.stackable.aipMergeType
+
+		inst.components.stackable.aipMergeType = function(this, other, source_pos)
+			if oldMergeType ~= nil then
+				if type(oldMergeType) == "function" then
+					if not oldMergeType(this, other, source_pos) then
+						return false
+					end
+				elseif type(oldMergeType) == "string" then
+					local otherMergeType = other.components.stackable ~= nil and other.components.stackable.aipMergeType or nil
+					if otherMergeType ~= oldMergeType then
+						return false
+					end
+				end
+			end
+
+			return getQuality(this) == getQuality(other)
+		end
+	end
+end
+
+-- 料理锅成品需要能承载食材平均品质。
+AddPrefabPostInitAny(function(inst)
+	if inst:HasTag("preparedfood") then
+		setupQuality(inst)
+		patchQualityStackable(inst)
+	end
+end)
 
 -- 有品质才加成；正数变强，负数变弱，普通品质不变。
 local function applyQualityBonus(value, edible)
@@ -62,5 +141,85 @@ AddComponentPostInit("cookable", function(self)
 		end
 
 		return product
+	end
+end)
+
+AddComponentPostInit("stewer", function(self)
+	local oldStartCooking = self.StartCooking
+	local oldStopCooking = self.StopCooking
+	local oldOnSave = self.OnSave
+	local oldOnLoad = self.OnLoad
+	local oldHarvest = self.Harvest
+
+	-- 开始烹饪前记录食材平均品质，避免锅具销毁内容后丢失。
+	function self:StartCooking(doer, ...)
+		local quality = nil
+		if self.targettime == nil and self.inst.components.container ~= nil then
+			quality = getAverageQuality(self.inst.components.container.slots)
+		end
+
+		oldStartCooking(self, doer, ...)
+
+		if quality ~= nil and self.product ~= nil and self.targettime ~= nil then
+			self.aip_product_quality = quality
+		end
+	end
+
+	function self:OnSave(...)
+		local data = oldOnSave(self, ...)
+		if data ~= nil and self.aip_product_quality ~= nil then
+			data.aip_product_quality = self.aip_product_quality
+		end
+		return data
+	end
+
+	function self:OnLoad(data, ...)
+		oldOnLoad(self, data, ...)
+		self.aip_product_quality = data ~= nil and data.aip_product_quality or nil
+	end
+
+	-- 在成品生成瞬间写入品质，后续食用效果沿用 edible 的品质倍率。
+	local function withQualitySpawn(fn, ...)
+		local product = self.product
+		local quality = self.aip_product_quality
+
+		if product == nil or quality == nil then
+			return fn(self, ...)
+		end
+
+		local oldSpawnPrefab = _G.SpawnPrefab
+		_G.SpawnPrefab = function(name, ...)
+			local inst = oldSpawnPrefab(name, ...)
+
+			if name == product and inst ~= nil and inst:HasTag("preparedfood") then
+				setupQuality(inst)
+				inst.components.aipc_quality:SetVal(quality)
+			end
+
+			return inst
+		end
+
+		local ok, result = pcall(fn, self, ...)
+		_G.SpawnPrefab = oldSpawnPrefab
+
+		if not ok then
+			error(result)
+		end
+
+		return result
+	end
+
+	function self:StopCooking(reason, ...)
+		local result = withQualitySpawn(oldStopCooking, reason, ...)
+		self.aip_product_quality = nil
+		return result
+	end
+
+	function self:Harvest(harvester, ...)
+		local result = withQualitySpawn(oldHarvest, harvester, ...)
+		if self.product == nil then
+			self.aip_product_quality = nil
+		end
+		return result
 	end
 end)

--- a/scripts/hooks/aip_edible_hook.lua
+++ b/scripts/hooks/aip_edible_hook.lua
@@ -211,11 +211,11 @@ AddComponentPostInit("stewer", function(self)
 			return inst
 		end
 
-		local ok, result = pcall(fn, self, ...)
+		local ok, result = _G.pcall(fn, self, ...)
 		_G.SpawnPrefab = oldSpawnPrefab
 
 		if not ok then
-			error(result)
+			_G.error(result)
 		end
 
 		return result

--- a/scripts/hooks/aip_edible_hook.lua
+++ b/scripts/hooks/aip_edible_hook.lua
@@ -3,7 +3,6 @@ local _G = GLOBAL
 -- 每高一级品质，正面效果增加 25%，负面效果减少 25%。
 local QUALITY_EFFECT_STEP = 0.25
 local DEFAULT_QUALITY = 1
-local POST_INIT_QUALITY_FOODS = {}
 
 -- 读取物品品质，没有品质的食材视作普通品质。
 local function getQuality(inst)
@@ -36,40 +35,11 @@ local function setupQuality(inst)
 end
 
 -- 有品质的料理只和同品质合堆，避免食用时品质被混掉。
-local function patchQualityStackableComponent(inst)
-	local stackable = inst.components.stackable
-
-	if stackable == nil or stackable._aip_quality_stackable_patched then
-		return
-	end
-	stackable._aip_quality_stackable_patched = true
-
-	local oldMergeType = stackable.aipMergeType
-	stackable.aipMergeType = function(this, other, source_pos)
-		if oldMergeType ~= nil then
-			if type(oldMergeType) == "function" then
-				if not oldMergeType(this, other, source_pos) then
-					return false
-				end
-			elseif type(oldMergeType) == "string" then
-				local otherMergeType = other.components.stackable ~= nil and other.components.stackable.aipMergeType or nil
-				if otherMergeType ~= oldMergeType then
-					return false
-				end
-			end
-		end
-
-		return getQuality(this) == getQuality(other)
-	end
-end
-
--- 有品质的料理只和同品质合堆，避免食用时品质被混掉。
 local function patchQualityStackable(inst)
-	if inst._aip_quality_stackable_fn_patched then
-		patchQualityStackableComponent(inst)
+	if inst._aip_quality_stackable_patched then
 		return
 	end
-	inst._aip_quality_stackable_fn_patched = true
+	inst._aip_quality_stackable_patched = true
 
 	local oldCanStackWithFn = inst.stackable_CanStackWithFn
 	inst.stackable_CanStackWithFn = function(this, other)
@@ -80,41 +50,35 @@ local function patchQualityStackable(inst)
 		return getQuality(this) == getQuality(other)
 	end
 
-	patchQualityStackableComponent(inst)
+	if inst.components.stackable ~= nil then
+		local oldMergeType = inst.components.stackable.aipMergeType
+
+		inst.components.stackable.aipMergeType = function(this, other, source_pos)
+			if oldMergeType ~= nil then
+				if type(oldMergeType) == "function" then
+					if not oldMergeType(this, other, source_pos) then
+						return false
+					end
+				elseif type(oldMergeType) == "string" then
+					local otherMergeType = other.components.stackable ~= nil and other.components.stackable.aipMergeType or nil
+					if otherMergeType ~= oldMergeType then
+						return false
+					end
+				end
+			end
+
+			return getQuality(this) == getQuality(other)
+		end
+	end
 end
 
 -- 料理锅成品需要能承载食材平均品质。
-local function setupPreparedFoodQuality(inst)
+AddPrefabPostInitAny(function(inst)
 	if inst:HasTag("preparedfood") then
 		setupQuality(inst)
 		patchQualityStackable(inst)
 	end
-end
-
--- 精确注册原版料理 prefab，避免每个 prefab 生成时都跑全局 Any hook。
-local function addPreparedFoodPostInit(name)
-	if name ~= nil and not POST_INIT_QUALITY_FOODS[name] then
-		POST_INIT_QUALITY_FOODS[name] = true
-		AddPrefabPostInit(name, setupPreparedFoodQuality)
-	end
-end
-
-local function addPreparedFoodPostInits(moduleName)
-	local ok, foods = pcall(_G.require, moduleName)
-	if not ok or foods == nil then
-		return
-	end
-
-	for name, data in pairs(foods) do
-		addPreparedFoodPostInit(data.name or name)
-	end
-end
-
-addPreparedFoodPostInits("preparedfoods")
-addPreparedFoodPostInits("preparedfoods_warly")
-addPreparedFoodPostInits("spicedfoods")
-
-_G.aipRegisterQualityPreparedFood = addPreparedFoodPostInit
+end)
 
 -- 有品质才加成；正数变强，负数变弱，普通品质不变。
 local function applyQualityBonus(value, edible)
@@ -141,9 +105,6 @@ AddComponentPostInit("edible", function(self)
 	local oldGetHunger = self.GetHunger
 	local oldGetSanity = self.GetSanity
 
-	-- 服务端添加 edible 时再次兜底，兼容其它已带 preparedfood 标签的料理。
-	setupPreparedFoodQuality(self.inst)
-
 	function self:GetHealth(eater, ...)
 		-- 生命先处理铁胃，再处理品质倍率。
 		local health = oldGetHealth(self, eater, ...)
@@ -164,12 +125,6 @@ AddComponentPostInit("edible", function(self)
 
 	function self:GetSanity(eater, ...)
 		return applyQualityBonus(oldGetSanity(self, eater, ...), self)
-	end
-end)
-
-AddComponentPostInit("stackable", function(self)
-	if self.inst:HasTag("preparedfood") and self.inst.components.aipc_quality ~= nil then
-		patchQualityStackable(self.inst)
 	end
 end)
 

--- a/scripts/prefabs/aip_endless_lotus.lua
+++ b/scripts/prefabs/aip_endless_lotus.lua
@@ -28,15 +28,15 @@ local LANG_MAP = {
 		ROOT_DESC = "Crisp and hollow-hearted.",
 	},
 	chinese = {
-		LOTUS_NAME = "无尽之莲",
+		LOTUS_NAME = "无限之莲",
 		LOTUS_DESC = "它在浪间静静绽放。",
-		SEED_NAME = "无尽之莲子",
+		SEED_NAME = "无限之莲子",
 		SEED_DESC = "它想落在一片安静的海面上。",
-		FLOWER_NAME = "无尽之莲花朵",
+		FLOWER_NAME = "无限之莲花朵",
 		FLOWER_DESC = "柔嫩得可以入口。",
-		LEAF_NAME = "无尽之莲荷叶",
+		LEAF_NAME = "无限之莲荷叶",
 		LEAF_DESC = "一片安静的青绿。",
-		ROOT_NAME = "无尽之莲藕",
+		ROOT_NAME = "无限之莲藕",
 		ROOT_DESC = "埋在水下的清脆根茎。",
 	},
 }
@@ -384,7 +384,7 @@ local function lotusFn()
 	return inst
 end
 
--- 创建可食用且可入锅的无尽之莲花朵。
+-- 创建可食用且可入锅的无限之莲花朵。
 local function flowerFn()
 	local inst = CreateEntity()
 
@@ -436,7 +436,7 @@ local function flowerFn()
 	return inst
 end
 
--- 创建暂时只用于掉落和收纳的无尽之莲荷叶。
+-- 创建暂时只用于掉落和收纳的无限之莲荷叶。
 local function leafFn()
 	local inst = CreateEntity()
 
@@ -478,7 +478,7 @@ local function leafFn()
 	return inst
 end
 
--- 创建可食用的无尽之莲藕。
+-- 创建可食用的无限之莲藕。
 local function rootFn()
 	local inst = CreateEntity()
 

--- a/scripts/prefabsHooker.lua
+++ b/scripts/prefabsHooker.lua
@@ -210,7 +210,7 @@ local FROG_LOTUS_SEED_DROP_CHANCE = 0.05
 
 AddPrefabPostInit("frog", function(inst)
 	if _G.TheWorld.ismastersim and inst.components.lootdropper ~= nil then
-		-- 青蛙死亡掉落表里小概率加入无尽之莲子。
+		-- 青蛙死亡掉落表里小概率加入无限之莲子。
 		inst.components.lootdropper:AddChanceLoot("aip_endless_lotus_seed", dev_mode and 1 or FROG_LOTUS_SEED_DROP_CHANCE)
 	end
 end)
@@ -1055,7 +1055,7 @@ for name, data in pairs(VEGGIES) do
 	env.AddIngredientValues({fullname}, data.tags or {}, data.cancook or false, data.candry or false)
 end
 
--- 让无尽之莲花朵与莲藕作为蔬菜进入料理锅，荷叶只作为命名配方材料。
+-- 让无限之莲花朵与莲藕作为蔬菜进入料理锅，荷叶只作为命名配方材料。
 local LOTUS_FLOWER_PREFAB = "aip_endless_lotus_flower"
 local LOTUS_LEAF_PREFAB = "aip_endless_lotus_leaf"
 local LOTUS_ROOT_PREFAB = "aip_endless_lotus_root"
@@ -1075,7 +1075,7 @@ env.RegisterInventoryItemAtlas(
 	LOTUS_ROOT_PREFAB..".tex"
 )
 
--- 让花沙拉把无尽之莲花朵视作仙人掌花材。
+-- 让花沙拉把无限之莲花朵视作仙人掌花材。
 local function PatchFlowerSaladRecipe(cooker)
 	local cooking = _G.require("cooking")
 	local recipes = cooking.recipes ~= nil and cooking.recipes[cooker] or nil

--- a/scripts/recpiesHooker.lua
+++ b/scripts/recpiesHooker.lua
@@ -5,6 +5,11 @@ local TECH_INGREDIENT = _G.TECH_INGREDIENT
 
 function GLOBAL.AddModPrefabCookerRecipe(cooker, recipe)
 	env.AddCookerRecipe(cooker, recipe)
+
+	-- 料理配方注册时同步注册品质初始化，避免使用全局 prefab post-init。
+	if GLOBAL.aipRegisterQualityPreparedFood ~= nil and recipe ~= nil then
+		GLOBAL.aipRegisterQualityPreparedFood(recipe.name)
+	end
 end
 
 local dev_mode = _G.aipGetModConfig("dev_mode") == "enabled"

--- a/scripts/recpiesHooker.lua
+++ b/scripts/recpiesHooker.lua
@@ -5,11 +5,6 @@ local TECH_INGREDIENT = _G.TECH_INGREDIENT
 
 function GLOBAL.AddModPrefabCookerRecipe(cooker, recipe)
 	env.AddCookerRecipe(cooker, recipe)
-
-	-- 料理配方注册时同步注册品质初始化，避免使用全局 prefab post-init。
-	if GLOBAL.aipRegisterQualityPreparedFood ~= nil and recipe ~= nil then
-		GLOBAL.aipRegisterQualityPreparedFood(recipe.name)
-	end
 end
 
 local dev_mode = _G.aipGetModConfig("dev_mode") == "enabled"


### PR DESCRIPTION
食物品质系统更新，料理锅制作出的食物现在会根据四份食材的平均品质获得对应品质，成品食用时会像高品质食材一样按品质强化生命、饥饿、理智的正面效果并削弱负面效果；带品质的料理会按品质区分合堆，避免不同品质混在一起影响食用收益；中文名中的无尽之莲统一调整为无限之莲，包含莲子、花朵、荷叶、莲藕和皮肤名称。