### PR TITLE
fix: 修复第三方血条显示异常

### DIFF
--- a/scripts/componentsHooker.lua
+++ b/scripts/componentsHooker.lua
@@ -495,10 +495,7 @@ AipPostComp("health", function(self)
 		local data = { amount = amount, afflicter = afflicter, cause = cause }
 		self.inst:PushEvent("aip_healthdelta", data)
 
-		if data.amount == 0 then
-			return
-		end
-
+		-- 0 变化也要走原版 DoDelta，用于触发生命同步与第三方血条刷新。
 		return originDoDelta(
 			self, data.amount, overtime, cause, ignore_invincible, afflicter, ignore_absorb, ...
 		)


### PR DESCRIPTION
第三方血条兼容修复，恢复生命值 0 变化时的原版生命同步流程，让蝴蝶等低生命生物在初始化最大生命、强制刷新或伤害被抵消后仍能正常广播生命变化，避免血条保留默认当前生命而出现底线横向拉长的问题；保留本模组生命变化事件的拦截能力，凤凰羽毛、钢球等将伤害归零的效果仍会生效，并同步刷新血条显示。